### PR TITLE
Add mmap_mode="c" to np.load() of .npy files in embedding.py

### DIFF
--- a/representations/embedding.py
+++ b/representations/embedding.py
@@ -33,9 +33,9 @@ class Embedding:
 
     @classmethod
     def load(cls, path, normalize=True, add_context=False, **kwargs):
-        mat = np.load(path + "-w.npy")
+        mat = np.load(path + "-w.npy", mmap_mode="c")
         if add_context:
-            mat += np.load(path + "-c.npy")
+            mat += np.load(path + "-c.npy", mmap_mode="c")
         iw = load_pickle(path + "-vocab.pkl")
         return cls(mat, iw, normalize) 
 
@@ -96,8 +96,8 @@ class SVDEmbedding(Embedding):
     """
     
     def __init__(self, path, normalize=True, eig=0.0, **kwargs):
-        ut = np.load(path + '-u.npy')
-        s = np.load(path + '-s.npy')
+        ut = np.load(path + '-u.npy', mmap_mode="c")
+        s = np.load(path + '-s.npy', mmap_mode="c")
         vocabfile = path + '-vocab.pkl'
         self.iw = load_pickle(vocabfile)
         self.wi = {w:i for i, w in enumerate(self.iw)}


### PR DESCRIPTION
using mode "c" means copy-on-write, so the files are loaded off disk using mmap
but not re-written to disk when changed.

* with cold file cache, running example.py takes ~4s vs 2.7s
* with hot cache, example.py takes 2.8s vs 1.8s

(for testing, i clear the fs cache using vmtouch tool: https://hoytech.com/vmtouch/)